### PR TITLE
Add apparmor profile

### DIFF
--- a/apparmor/kopano-webapp
+++ b/apparmor/kopano-webapp
@@ -1,0 +1,28 @@
+# Author: Guido Günther <agx@sigxcpu.org>
+
+  ^kopano-webapp {
+    #include <abstractions/apache2-common>
+    #include <abstractions/base>
+    #include <abstractions/nameservice>
+    #include <abstractions/php5>
+
+    @{PROC}/@{pid}/task/@{tid}/comm rw,
+    @{PROC}/@{pid}/cmdline r,
+
+    /etc/gss/mech.d/ r,
+    /etc/gss/mech.d/*.conf r,
+
+    /etc/kopano/webapp/*.php r,
+
+    /usr/share/kopano-webapp/** r,
+
+    /var/lib/kopano-webapp/tmp/** rwk,
+
+    /var/log/apache2/ r,
+    # FIXME: we should use separate logfiles for kopano upfront
+    /var/log/apache2/error.log rw,
+    /var/log/apache2/other_vhosts_access.log rw,
+
+    # Useful when in debugging mode
+    /usr/share/kopano-webapp/debug.txt rw,
+  }

--- a/kopano-webapp.conf
+++ b/kopano-webapp.conf
@@ -11,6 +11,10 @@ Alias /webapp /usr/share/kopano-webapp
     DirectoryIndex index.php
     Options -Indexes +FollowSymLinks
 
+    <IfModule apparmor_module>
+      AAHatName kopano-webapp
+    </IfModule>
+
     <IfVersion < 2.4>
 	Allow from all
 	AllowOverride Options Limit


### PR DESCRIPTION
and enable it in the apache example config iff the mod_apparmor is
enabled in apache.

The apparmor profile itself isn't installed anywhere at the moment but I'm happy to add that once the switch to make happened. This is what we're doing in Debian atm:

    https://anonscm.debian.org/cgit/pkg-giraffe/kopano-webapp.git/commit/?id=7310d19e1de2bb028f81a5971de724e7af62d5a5
    
to enable it in the postinst.